### PR TITLE
Cope with multiple networks on the same vlan_id + nic_tag

### DIFF
--- a/lib/models/nic/common.js
+++ b/lib/models/nic/common.js
@@ -22,7 +22,7 @@ var mod_portolan_moray = require('portolan-moray');
 var util = require('util');
 var util_mac = require('../../util/mac');
 var validate = require('../../util/validate');
-
+var vasync = require('vasync');
 
 
 // --- Globals
@@ -229,17 +229,49 @@ function validateNetworkParams(opts, params, parsedParams, callback) {
             }));
         }
 
-        if (res.length !== 1) {
-            return callback(['nic_tag', 'vlan_id'].map(function (p) {
-                return errors.invalidParam(p,
-                'Too many networks found matching parameters');
-            }));
-        }
+        /*
+         * Handle the case where we have multiple subnets on one vlan ID
+         * by checking that our address is within one of the found networks.
+         */
 
-        parsedParams.network = res[0];
-        parsedParams.network_uuid = res[0].uuid;
-
-        return validateSubnetContainsIP(opts, parsedParams, callback);
+        vasync.forEachParallel({
+            func: function (network, cb) {
+                var prms = Object.create(parsedParams);
+                prms.network = network;
+                prms.network_uuid = network.uuid;
+                validateSubnetContainsIP(opts, prms, function (e) {
+                    if (e)
+                        cb(null, {input: network, result: false});
+                    else
+                        cb(null, {input: network, result: true});
+                });
+            },
+            inputs: res
+        }, function (err2, res2) {
+            var contained = res2.operations.filter(function (op) {
+                return (typeof (op.result) === 'object' &&
+                    op.result.result === true);
+            }).map(function (op) {
+                return (op.result.input);
+            });
+            if (contained.length < 1) {
+                return (callback(['ip', 'netmask'].map(function (p) {
+                    return (errors.invalidParam(p, 'No networks matching ' +
+                        'parameters contained this address'));
+                })));
+            }
+            if (contained.length > 1) {
+                var uuids = contained.map(function (n) { return (n.uuid); });
+                return (callback(['ip', 'netmask'].map(function (p) {
+                    return (errors.invalidParam(p, 'Multiple overlapping ' +
+                        'networks (' + uuids.join(', ') + ') contain this ' +
+                        'address'));
+                })));
+            }
+            parsedParams.network = contained[0].input;
+            parsedParams.network_uuid = contained[0].input.uuid;
+            return (callback(null));
+        });
     });
 }
 


### PR DESCRIPTION
When you have multiple networks that share the same vlan_id + nic_tag and you have a VM allocated on one of them that's found by a heartbeat request (ie, not created before the heartbeat comes in, for any of various reasons, including a VM that's been moved by vmadm send), currently you just get an error saying the NIC is invalid.

However, the code for this can happily check through the list of networks that match the vlan_id + nic_tag for one that contains the address on the NIC, and use that if one is found. This patch adds this functionality.

If we don't find one, then we return a new error that's a bit more specific than the previous one (no networks contained the ip/netmask).