### PR TITLE
Fixed to avoid toString() on null return objects

### DIFF
--- a/lib/models/network.js
+++ b/lib/models/network.js
@@ -934,7 +934,10 @@ Network.prototype.raw = function networkRaw(opts) {
 
     if (this.params.hasOwnProperty('resolvers')) {
         raw.resolver_addrs = this.params.resolvers.map(function (r) {
-            return r.toString();
+           if ( r != null )
+             return r.toString();
+           else
+             return 'NaN';
         });
 
         // Rollback-compatibility:

--- a/lib/models/network.js
+++ b/lib/models/network.js
@@ -998,7 +998,10 @@ Network.prototype.serialize = function networkSerialize(opts) {
 
     if (this.params.resolvers) {
         ser.resolvers = this.params.resolvers.map(function (r) {
-            return r.toString();
+            if ( r != null )
+              return r.toString();
+            else
+              return 'NaN';
         });
     } else {
         ser.resolvers = [];


### PR DESCRIPTION
Got this when my resolver where empty, using NaN as the return string might not be the best, but works for me.