### PR TITLE
Translate name -> name_str when updating networks

### DIFF
--- a/lib/models/network.js
+++ b/lib/models/network.js
@@ -1273,12 +1273,17 @@ function updateNetwork(opts, callback) {
 
         // -- moray-only values
 
-        ['name', 'description', 'provision_start_ip',
-            'provision_end_ip', 'mtu', 'ip_use_strings'].forEach(function (p) {
+        ['description', 'provision_start_ip', 'provision_end_ip', 'mtu',
+                'ip_use_strings'].forEach(function (p) {
             if (validated.hasOwnProperty(p)) {
                 batch[0].value[p] = validated[p].toString();
             }
         });
+
+        if (validated.hasOwnProperty('name')) {
+            batch[0].value.name = validated.name.toString();
+            batch[0].value.name_str = nameStr(batch[0].value);
+        }
 
         if (validated.hasOwnProperty('owner_uuids')) {
             batch[0].value.owner_uuids =


### PR DESCRIPTION
After the name_str changes, the update/PUT path for networks
seems to have been forgotten. It was still writing the old
"name" property and not "name_str".