### PR TITLE
Let toIPAddr handle {octets:[..]} objects properly

### DIFF
--- a/lib/util/ip.js
+++ b/lib/util/ip.js
@@ -42,7 +42,12 @@ function toIPAddr(addr) {
     if (addr instanceof ipaddr.IPv4 || addr instanceof ipaddr.IPv6) {
         return addr;
     }
-
+    if (typeof (addr) === 'object') {
+        if (addr.octets)
+            return ipaddr.parse(addr.octets.join('.'));
+        else if (addr.parts)
+            return ipaddr.parse(addr.parts.join(':'));
+    }
     // XXX We want to be able to parse numbers as IP addresses to support the
     // legacy IP tables where addresses were stored as numbers. ipaddr.js will
     // parse decimal numbers (in string form) as IP addresses for IPv4 (see


### PR DESCRIPTION
These end up appearing during update (PUT) operations on networks that update their `resolvers` lists, and currently get turned into `null`, which causes crashes and other bad behaviour.